### PR TITLE
Bugfixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,8 @@ set(WCSIM_SCRIPTS
   dirtdirectory.txt
   WCSimVersion.txt
   CommitHash.txt
+  PMTPositions_Scan_Glass.txt
+  PMTPositions_Scan.txt
   )
 
 foreach(_script ${WCSIM_SCRIPTS})
@@ -214,6 +216,21 @@ foreach(_script ${WCSIM_SCRIPTS})
     ${PROJECT_BINARY_DIR}/${_script}
     COPYONLY
     )
+endforeach()
+
+set(MRD_SCRIPTS
+   mrdmodule.txt
+   mrdposition.txt
+   mrd-align.txt
+   mrdnoisehit.txt
+   )
+
+foreach(_script ${MRD_SCRIPTS})
+  configure_file(
+    ${PROJECT_SOURCE_DIR}/src/${_script}
+    ${PROJECT_BINARY_DIR}/${_script}
+    COPYONLY
+  )
 endforeach()
 
 # dunno why but on sl7 we seem to need to copy these manually?

--- a/macros/primaries_directory.mac
+++ b/macros/primaries_directory.mac
@@ -1,5 +1,7 @@
 # set the list of root files containing primaries to import into the primary generator TChain
 # be sure that the neutrinosDirectory is set before setting the primariesDirectory!
-/mygen/neutrinosdirectory /home/marc/LinuxSystemFiles/WChSandBox/build/fluxesandtables/gntp.*.ghep.root
-/mygen/primariesdirectory /home/marc/LinuxSystemFiles/WChSandBox/build/fluxesandtables/annie_tank_flux.*.root
+#/mygen/neutrinosdirectory /home/marc/LinuxSystemFiles/WChSandBox/build/fluxesandtables/gntp.*.ghep.root
+#/mygen/primariesdirectory /home/marc/LinuxSystemFiles/WChSandBox/build/fluxesandtables/annie_tank_flux.*.root
+/mygen/neutrinosdirectory /pnfs/annie/persistent/users/vfischer/genie_files/BNB_Water_10k_22-05-17/gntp.*.ghep.root
+/mygen/primariesdirectory /pnfs/annie/persistent/users/moflaher/g4dirt_vincentsgenie/BNB_Water_10k_22-05-17/annie_tank_flux.*.root
 /mygen/primariesoffset 0

--- a/macros/visOGLSX.mac
+++ b/macros/visOGLSX.mac
@@ -53,24 +53,24 @@
 /vis/geometry/set/colour WCCapBlackSheet -1 0.5 0.5 0.5 0.3
 
 # PMT colours
-/vis/geometry/set/visibility ANNIEp2v6-glassFaceWCPMT_R7081 -1 1
-/vis/geometry/set/visibility ANNIEp2v6-glassFaceWCPMT_D784KFLB -1 1
-/vis/geometry/set/visibility ANNIEp2v6-glassFaceWCPMT_R5912HQE -1 1
-/vis/geometry/set/visibility ANNIEp2v6-glassFaceWCPMT_R7081HQE -1 1
-/vis/geometry/set/visibility ANNIEp2v6-glassFaceWCONLYLAPPDS -1 1
-/vis/geometry/set/visibility ANNIEp2v6-glassFaceWCPMT_EMI9954KB -1 1
-/vis/geometry/set/forceSolid ANNIEp2v6-glassFaceWCPMT_R7081 -1 1
-/vis/geometry/set/forceSolid ANNIEp2v6-glassFaceWCPMT_D784KFLB -1 1
-/vis/geometry/set/forceSolid ANNIEp2v6-glassFaceWCPMT_R5912HQE -1 1
-/vis/geometry/set/forceSolid ANNIEp2v6-glassFaceWCPMT_R7081HQE -1 1
-/vis/geometry/set/forceSolid ANNIEp2v6-glassFaceWCONLYLAPPDS -1 1
-/vis/geometry/set/forceSolid ANNIEp2v6-glassFaceWCPMT_EMI9954KB -1 1
-/vis/geometry/set/colour ANNIEp2v6-glassFaceWCPMT_R7081 -1 1. .6 1. 1
-/vis/geometry/set/colour ANNIEp2v6-glassFaceWCPMT_D784KFLB -1 .6 1. 1. 1
-/vis/geometry/set/colour ANNIEp2v6-glassFaceWCPMT_R5912HQE -1 .6 .6 1. 1
-/vis/geometry/set/colour ANNIEp2v6-glassFaceWCPMT_R7081HQE -1 1.0 0.3 .3 1
-/vis/geometry/set/colour ANNIEp2v6-glassFaceWCONLYLAPPDS -1 0.6 0.8 0.5 1
-/vis/geometry/set/colour ANNIEp2v6-glassFaceWCPMT_EMI9954KB -1 1.0 0.3 .3 1
+/vis/geometry/set/visibility ANNIEp2v7-glassFaceWCPMT_R7081 -1 1
+/vis/geometry/set/visibility ANNIEp2v7-glassFaceWCPMT_D784KFLB -1 1
+/vis/geometry/set/visibility ANNIEp2v7-glassFaceWCPMT_R5912HQE -1 1
+/vis/geometry/set/visibility ANNIEp2v7-glassFaceWCPMT_R7081HQE -1 1
+/vis/geometry/set/visibility ANNIEp2v7-glassFaceWCONLYLAPPDS -1 1
+/vis/geometry/set/visibility ANNIEp2v7-glassFaceWCPMT_EMI9954KB -1 1
+/vis/geometry/set/forceSolid ANNIEp2v7-glassFaceWCPMT_R7081 -1 1
+/vis/geometry/set/forceSolid ANNIEp2v7-glassFaceWCPMT_D784KFLB -1 1
+/vis/geometry/set/forceSolid ANNIEp2v7-glassFaceWCPMT_R5912HQE -1 1
+/vis/geometry/set/forceSolid ANNIEp2v7-glassFaceWCPMT_R7081HQE -1 1
+/vis/geometry/set/forceSolid ANNIEp2v7-glassFaceWCONLYLAPPDS -1 1
+/vis/geometry/set/forceSolid ANNIEp2v7-glassFaceWCPMT_EMI9954KB -1 1
+/vis/geometry/set/colour ANNIEp2v7-glassFaceWCPMT_R7081 -1 1. .6 1. 1
+/vis/geometry/set/colour ANNIEp2v7-glassFaceWCPMT_D784KFLB -1 .6 1. 1. 1
+/vis/geometry/set/colour ANNIEp2v7-glassFaceWCPMT_R5912HQE -1 .6 .6 1. 1
+/vis/geometry/set/colour ANNIEp2v7-glassFaceWCPMT_R7081HQE -1 1.0 0.3 .3 1
+/vis/geometry/set/colour ANNIEp2v7-glassFaceWCONLYLAPPDS -1 0.6 0.8 0.5 1
+/vis/geometry/set/colour ANNIEp2v7-glassFaceWCPMT_EMI9954KB -1 1.0 0.3 .3 1
 
 ## MRD
 #/vis/geometry/set/forceSolid hpaddle_log -1 1
@@ -86,7 +86,7 @@
 #/vis/geometry/set/colour lg_log2 -1 0.6 0.4 0.4 0.4
 #/vis/geometry/set/colour steel_log -1 0.3 0.3 0.3 0.4
 ##/vis/geometry/set/colour aluStruct -1 0.7 0.7 0.7 0.4
-#/vis/geometry/set/colour ANNIEp2v6-glassFaceWCPMT_MRD -1 0.7 0.7 0.7 0.3
+#/vis/geometry/set/colour ANNIEp2v7-glassFaceWCPMT_MRD -1 0.7 0.7 0.7 0.3
 #/vis/geometry/set/forceSolid MRDAlV1_LV -1 1
 #/vis/geometry/set/forceSolid MRDAlV2_LV -1 1
 #/vis/geometry/set/forceSolid MRDAlV3_LV -1 1
@@ -117,7 +117,7 @@
 /vis/geometry/set/colour lg_log -1 0.5 0.5 0.5 0.4
 /vis/geometry/set/colour lg_log2 -1 0.5 0.5 0.5 0.4
 /vis/geometry/set/colour steel_log -1 0.5 0.5 0.5 1.0
-/vis/geometry/set/colour ANNIEp2v6-glassFaceWCPMT_MRD -1 0.5 0.5 0.5 0.3
+/vis/geometry/set/colour ANNIEp2v7-glassFaceWCPMT_MRD -1 0.5 0.5 0.5 0.3
 /vis/geometry/set/forceSolid MRDAlV1_LV -1 1
 /vis/geometry/set/forceSolid MRDAlV2_LV -1 1
 /vis/geometry/set/forceSolid MRDAlV3_LV -1 1
@@ -133,7 +133,7 @@
 /vis/geometry/set/colour vetoPaddle_log -1 0.5 0.5 0.5 0.5
 /vis/geometry/set/colour vetol2Paddle_log  -1 0.5 0.5 0.5 0.4
 /vis/geometry/set/colour vetolg_log -1 0.5 0.5 0.5 0.4
-/vis/geometry/set/colour ANNIEp2v6-glassFaceWCPMT_FACC -1 0.5 0.5 0.5 0.3
+/vis/geometry/set/colour ANNIEp2v7-glassFaceWCPMT_FACC -1 0.5 0.5 0.5 0.3
 
 #/vis/viewer/flush
 #/vis/ogl/set/printMode pixmap
@@ -150,18 +150,18 @@
 #/vis/geometry/set/visibility taper_log -1 0
 #/vis/geometry/set/colour totVetolog -1 0 0 0 0
 #/vis/geometry/set/colour totVetolog -1 1 1 1 0.5  # outline, for orientation
-#/vis/geometry/set/colour ANNIEp2v6-glassFaceWCONLYLAPPDS -1 0 0 0 0
-#/vis/geometry/set/colour ANNIEp2v6-glassFaceWCPMT_R7081 -1 0 0 0 0
-#/vis/geometry/set/colour ANNIEp2v6-glassFaceWCPMT_D784KFLB -1  0 0 0 0
-#/vis/geometry/set/colour ANNIEp2v6-glassFaceWCPMT_R5912HQE -1  0 0 0 0
-#/vis/geometry/set/colour ANNIEp2v6-glassFaceWCPMT_R7081HQE -1  0 0 0 0
-#/vis/geometry/set/colour ANNIEp2v6-glassFaceWCPMT_EMI9954KB -1  0 0 0 0
-#/vis/geometry/set/visibility ANNIEp2v6-glassFaceWCPMT_R7081 -1 0
-#/vis/geometry/set/visibility ANNIEp2v6-glassFaceWCPMT_D784KFLB -1 0
-#/vis/geometry/set/visibility ANNIEp2v6-glassFaceWCPMT_R5912HQE -1 0
-#/vis/geometry/set/visibility ANNIEp2v6-glassFaceWCPMT_R7081HQE -1 0
-#/vis/geometry/set/visibility ANNIEp2v6-glassFaceWCONLYLAPPDS -1 0
-#/vis/geometry/set/colour ANNIEp2v6-glassFaceWCPMT_EMI9954KB -1  0 0 0 0
+#/vis/geometry/set/colour ANNIEp2v7-glassFaceWCONLYLAPPDS -1 0 0 0 0
+#/vis/geometry/set/colour ANNIEp2v7-glassFaceWCPMT_R7081 -1 0 0 0 0
+#/vis/geometry/set/colour ANNIEp2v7-glassFaceWCPMT_D784KFLB -1  0 0 0 0
+#/vis/geometry/set/colour ANNIEp2v7-glassFaceWCPMT_R5912HQE -1  0 0 0 0
+#/vis/geometry/set/colour ANNIEp2v7-glassFaceWCPMT_R7081HQE -1  0 0 0 0
+#/vis/geometry/set/colour ANNIEp2v7-glassFaceWCPMT_EMI9954KB -1  0 0 0 0
+#/vis/geometry/set/visibility ANNIEp2v7-glassFaceWCPMT_R7081 -1 0
+#/vis/geometry/set/visibility ANNIEp2v7-glassFaceWCPMT_D784KFLB -1 0
+#/vis/geometry/set/visibility ANNIEp2v7-glassFaceWCPMT_R5912HQE -1 0
+#/vis/geometry/set/visibility ANNIEp2v7-glassFaceWCPMT_R7081HQE -1 0
+#/vis/geometry/set/visibility ANNIEp2v7-glassFaceWCONLYLAPPDS -1 0
+#/vis/geometry/set/colour ANNIEp2v7-glassFaceWCPMT_EMI9954KB -1  0 0 0 0
 
 # colours for the MRD paddles. Not very effective unless really zoomed in.
 #/vis/geometry/set/visibility hpaddle_log  -1 1

--- a/src/SBsimMRDDB.cc
+++ b/src/SBsimMRDDB.cc
@@ -17,10 +17,10 @@ SBsimMRDDB::SBsimMRDDB()
 ////////////////////////
 {
   //SetModuleInfo((char*)"database/mrdgeom/mrdmodule.txt");
-  SetModuleInfo((char*)"../WCSim/src/mrdmodule.txt");
-  SetPositionInfo((char*)"../WCSim/src/mrdposition.txt");
-  SetAlignmentInfo("../WCSim/src/mrd-align.txt");
-  SetNoiseHitInfo((char*)"../WCSim/src/mrdnoisehit.txt");
+  SetModuleInfo((char*)"mrdmodule.txt");
+  SetPositionInfo((char*)"mrdposition.txt");
+  SetAlignmentInfo("mrd-align.txt");
+  SetNoiseHitInfo((char*)"mrdnoisehit.txt");
 }
 
 /////////////////////////


### PR DESCRIPTION
* Make CMakeLists copy over new PMTPosition files to build directory.
* Also copy over mrd text files and update src/SBsimMRDDB.cc to remove hard-coded sourcefiles path and folder name.
* Update visOGLSX.mac logical volume names to ANNIEp2v7.
* Update primaries_directory to have a default that works on gpvm machines.