### PR TITLE
Disabled PMTwiseQE in macros/tuning_parameters.mac

### DIFF
--- a/macros/tuning_parameters.mac
+++ b/macros/tuning_parameters.mac
@@ -19,7 +19,7 @@
 /WCSim/tuning/holder 1
 
 #Turning PMT-wise Q.E. on (1) or off (0)
-/WCSim/tuning/PMTwiseQE 1
+/WCSim/tuning/PMTwiseQE 0
 
 # Parameters to set up Top Veto - jl145
 # Set to "1" to turn on top veto.


### PR DESCRIPTION
With PMTwiseQE enabled, the program will not run and will produced the following error: 
```
terminate called after throwing an instance of 'std::bad_alloc'
  what():  std::bad_alloc
Aborted
```
which is caused by the program staying in the while loop at WCSimWCSD.cc:348 until it uses all available memory. 

This error took me a nontrivial amount of time to debug. This problem can be avoided by just disabling the option in the included macro. Alternatively, we could provided the needed file `../WCSim/pmt_qe.txt` which would also solve this problem. I think that, by default, the program should run without any needed files, and if the user wants, they can easily enable the option. 