### PR TITLE
Added DirectParentID & Primary "ParentID" in WCSimRootCherenkovHitTime,  WCSimRootTrack, WCSimTrackInformation etc and made corresponding changes in WCSim.

### DIFF
--- a/WCSim.mac
+++ b/WCSim.mac
@@ -459,7 +459,7 @@
 #/WCSimIO/RootFile ANNIEtest_MRD_muon_sample  # for MRD range vs energy estimation
 #/WCSimIO/RootFile wcsim_Muon_Tank_Sample_killed # for measuring # digits vs energy loss in tank
 
-#/run/beamOn 1
+/run/beamOn 1000
 # should run 10000 events for bonsai
 
 #exit

--- a/WCSim.mac
+++ b/WCSim.mac
@@ -459,7 +459,7 @@
 #/WCSimIO/RootFile ANNIEtest_MRD_muon_sample  # for MRD range vs energy estimation
 #/WCSimIO/RootFile wcsim_Muon_Tank_Sample_killed # for measuring # digits vs energy loss in tank
 
-/run/beamOn 1000
+/run/beamOn 20
 # should run 10000 events for bonsai
 
 #exit

--- a/include/WCSimEventAction.hh
+++ b/include/WCSimEventAction.hh
@@ -111,6 +111,7 @@ private:
   std::vector<double> lappdhit_globalcoorz;
   std::vector<float> lappdhit_truetime2, lappdhit_smeartime2;
   std::vector<int>   lappdhit_primaryParentID2;	
+  std::vector<int>   lappdhit_directParentID2;
   std::vector<int> lappdhit_stripnum;
 };
 

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -52,9 +52,15 @@ private:
   Float_t fTankExitPos[3];
   Double_t fTankExitE;
   Float_t fTankExitMom[3];
+  Int_t fPrimaryParentID;  
+  Int_t fDirectParentID;
 
 public:
-  WCSimRootTrack() {}
+  WCSimRootTrack() : fIpnu(0), fFlag(0), fM(0), fP(0), fE(0), fP2(0), fE2(0), 
+    fStartvol(0), fStopvol(0), fParenttype(0), fTime(0), fTime2(0), fId(0),
+    fTankExitE(0), fPrimaryParentID(-1), fDirectParentID(-1) {
+      for(int i=0; i<3; i++) { fDir[i]=0; fPdir[i]=0; fPdir2[i]=0; fStop[i]=0; fStart[i]=0; fTankExitPos[i]=0; fTankExitMom[i]=0; }
+    }
   WCSimRootTrack(Int_t ipnu, 
 		  Int_t flag, 
 		  Float_t m, 
@@ -77,7 +83,9 @@ public:
 		  std::string eProcess,
 		  Float_t tankexitp[3],
 		  Double_t tankexite,
-		  Float_t tankexitmom[3]);
+      Float_t tankexitmom[3],
+      Int_t primaryParentID,
+      Int_t directParentID);
   
   virtual ~WCSimRootTrack() { }
 
@@ -104,10 +112,12 @@ public:
   Float_t   GetTankExitPoint(Int_t i=0){return (i<3) ? fTankExitPos[i] : 0;}
   Double_t  GetTankExitE(){return fTankExitE;}
   Float_t   GetTankExitMom(Int_t i=0){return (i<3) ? fTankExitMom[i] : 0;}
+  Int_t     GetPrimaryParentID() { return fPrimaryParentID;}
+  Int_t     GetDirectParentID() { return fDirectParentID;}
   
   void Clear(Option_t *option ="");
 
-  ClassDef(WCSimRootTrack,1)  
+  ClassDef(WCSimRootTrack,6)  
 };
 
 
@@ -139,17 +149,20 @@ private:
   // See jhfNtuple.h for the meaning of these data members:
   Float_t fTruetime;
   Int_t   fPrimaryParentID;
+  Int_t  fDirectParentID;
 
 public:
-  WCSimRootCherenkovHitTime() {}
+  WCSimRootCherenkovHitTime() : fTruetime(0), fPrimaryParentID(-1), fDirectParentID(-1) {}
   WCSimRootCherenkovHitTime(Float_t truetime,
-			    Int_t   primaryParentID);
+			    Int_t   primaryParentID,
+			    Int_t   directParentID);
   virtual ~WCSimRootCherenkovHitTime() { }
 
   Float_t   GetTruetime() { return fTruetime;}
-  Int_t     GetParentID() { return fPrimaryParentID;}
+  Int_t     GetPrimaryParentID() { return fPrimaryParentID;}
+  Int_t     GetDirectParentID() { return fDirectParentID;}
 
-  ClassDef(WCSimRootCherenkovHitTime,1)  
+  ClassDef(WCSimRootCherenkovHitTime,6)  
 };
 
 
@@ -490,7 +503,9 @@ public:
 				   std::string eProcess,
 				   Float_t TankExitPoint[3],
 				   Double_t TankExitE,
-				   Float_t TankExitMom[3]);
+				   Float_t TankExitMom[3],
+				   Int_t primaryParentID,
+				   Int_t directParentID);
 
   TClonesArray        *GetTracks() const {return fTracks;}
   
@@ -498,7 +513,8 @@ public:
 
   WCSimRootCherenkovHit   *AddCherenkovHit(Int_t                tubeID,
 					  std::vector<Float_t> truetime,
-					  std::vector<Int_t>   primParID);
+            std::vector<Int_t>   primParID,
+					  std::vector<Int_t>   directParID);
   TClonesArray        *GetCherenkovHits() const {return fCherenkovHits;}
   TClonesArray        *GetCherenkovHitTimes() const {return fCherenkovHitTimes;}
 

--- a/include/WCSimTrackInformation.hh
+++ b/include/WCSimTrackInformation.hh
@@ -15,14 +15,16 @@ class WCSimTrackInformation : public G4VUserTrackInformation {
 private:
   G4bool saveit;
   G4int  primaryParentID;
+  G4int directParentID;
   G4int  parentPdg;
   //long long int numreflections;
 
 public:
-  WCSimTrackInformation() : saveit(false), primaryParentID(-1), parentPdg(0)/*, numreflections(-1)*/ {}
+  WCSimTrackInformation() : saveit(false), primaryParentID(-1), directParentID(-1), parentPdg(0)/*, numreflections(-1)*/ {}
   WCSimTrackInformation(const WCSimTrackInformation* aninfo){
     saveit = aninfo->saveit;
     primaryParentID = aninfo->primaryParentID;
+    directParentID = aninfo->directParentID;
     parentPdg = aninfo->parentPdg;
     //numreflections = aninfo->numreflections;
   }
@@ -34,6 +36,9 @@ public:
 
   void SetPrimaryParentID(G4int i) { primaryParentID = i;}
   G4int GetPrimaryParentID() {return primaryParentID;}
+
+  void SetDirectParentID(G4int i) { directParentID = i;}
+  G4int GetDirectParentID() {return directParentID;}
 
   void SetParentPdg(G4int i) { parentPdg = i;}
   G4int GetParentPdg() { return parentPdg;}

--- a/include/WCSimTrajectory.hh
+++ b/include/WCSimTrajectory.hh
@@ -45,6 +45,8 @@ public: // with description
    { return fTrackID; }
    inline G4int GetParentID() const
    { return fParentID; }
+   inline G4int GetPrimaryParentID() const
+   { return fPrimaryParentID; }
    inline G4int GetParentPdg() const
    { return fParentPdg; }
    inline G4String GetParticleName() const
@@ -99,6 +101,8 @@ public: // with description
    { momentumOnTankExit = currentMomentum; }
    inline void SetTankExitPoint(G4ThreeVector& currentPosition)
    { tankExitPoint = currentPosition; }
+      inline void SetPrimaryParentID(G4int id)
+   { fPrimaryParentID = id; }
 
 
 // Other member functions
@@ -122,6 +126,7 @@ public: // with description
   TrajectoryPointContainer* positionRecord;
   G4int                     fTrackID;
   G4int                     fParentID;
+  G4int                     fPrimaryParentID;
   G4int                     fParentPdg;
   G4int                     PDGEncoding;
   G4double                  PDGCharge;

--- a/include/WCSimWCDigi.hh
+++ b/include/WCSimWCDigi.hh
@@ -70,6 +70,7 @@ private:
    */
   std::map<int, std::vector<int> > fDigiComp;
   std::map<int, G4int>    primaryParentID; ///< Primary parent ID of the Hit (do not use for Digits)
+  std::map<int, G4int>    directParentID;
   std::map<int, G4int>    stripno;
   std::map<int, std::map<int,double>> neigh_strips_peaks;
   std::map<int, std::map<int,double>> neigh_strips_times;
@@ -95,7 +96,8 @@ public:
   inline void SetPe(G4int gate,  G4float Q)      {pe[gate]     = Q;};
   inline void SetTime(G4int gate, G4float T)    {time[gate]   = T;};
   inline void SetPreSmearTime(G4int gate, G4float T)    {time_presmear[gate]   = T;};
-  inline void SetParentID(G4int gate, G4int parent) { primaryParentID[gate] = parent; };
+  inline void SetPrimaryParentID(G4int gate, G4int parent) { primaryParentID[gate] = parent; };
+  inline void SetDirectParentID(G4int gate, G4int directparent) { directParentID[gate] = directparent; };
   inline void SetStripNo(G4int gate, G4int strip){ stripno[gate] = strip; };
   inline void SetNeighStripNo(G4int gate, std::map<int,double> neighstrip ){ neigh_strips_peaks[gate]=neighstrip; };
   inline void SetNeighStripTime(G4int gate, std::map<int,double> neighstriptime ){ neigh_strips_times[gate]=neighstriptime; };
@@ -113,7 +115,8 @@ public:
     digi_comp.clear();
   }
 
-  inline G4int   GetParentID(int gate) { return primaryParentID.at(gate);};
+  inline G4int   GetPrimaryParentID(int gate) { return primaryParentID.at(gate);};
+  inline G4int   GetDirectParentID(int gate) { return directParentID.at(gate);};
   inline G4float GetGateTime(int gate) { return TriggerTimes.at(gate);}
   inline G4int   GetTubeID() {return tubeID;};
   inline G4int   GetLAPPDID() {return lappdID;};

--- a/include/WCSimWCHit.hh
+++ b/include/WCSimWCHit.hh
@@ -66,9 +66,10 @@ class WCSimWCHit : public G4VHit
   void SetPos          (G4ThreeVector xyz)          { pos = xyz; };
   void SetRot          (G4RotationMatrix rotMatrix) { rot = rotMatrix; };
   void SetLogicalVolume(G4LogicalVolume* logV)      { pLogV = logV;}
-  void AddParentID     (G4int primParentID)
+  void AddPrimaryParentID(G4int primParentID)
   { primaryParentID.push_back(primParentID); }
-
+  void AddDirectParentID(G4int directParID)
+  { directParentID.push_back(directParID); }
   // This is temporarily used for the drawing scale
   static void SetMaxPe(G4int number = 0)  {maxPe   = number;};
 
@@ -93,7 +94,8 @@ class WCSimWCHit : public G4VHit
   void AddHitPos(G4ThreeVector pos) { globalposition.push_back(pos); }
   G4int         GetTotalPe()    { return totalPe;};
   G4float       GetTime(int i)  { return time.at(i);};
-  G4int         GetParentID(int i) { return primaryParentID.at(i);};
+  G4int         GetPrimaryParentID(int i) { return primaryParentID.at(i);};
+  G4int         GetDirectParentID(int i) { return directParentID.at(i);};
   
   G4LogicalVolume* GetLogicalVolume() {return pLogV;};
 
@@ -169,6 +171,7 @@ class WCSimWCHit : public G4VHit
   std::vector<G4float>  time;
   std::vector<G4int>    primaryParentID;
   G4int                 totalPeInGate;
+  std::vector<G4int>    directParentID;
 };
 
 typedef G4THitsCollection<WCSimWCHit> WCSimWCHitsCollection;

--- a/macros/primaries_directory.mac
+++ b/macros/primaries_directory.mac
@@ -2,6 +2,12 @@
 # be sure that the neutrinosDirectory is set before setting the primariesDirectory!
 #/mygen/neutrinosdirectory /home/marc/LinuxSystemFiles/WChSandBox/build/fluxesandtables/gntp.*.ghep.root
 #/mygen/primariesdirectory /home/marc/LinuxSystemFiles/WChSandBox/build/fluxesandtables/annie_tank_flux.*.root
-/mygen/neutrinosdirectory /pnfs/annie/persistent/users/vfischer/genie_files/BNB_Water_10k_22-05-17/gntp.*.ghep.root
-/mygen/primariesdirectory /pnfs/annie/persistent/users/moflaher/g4dirt_vincentsgenie/BNB_Water_10k_22-05-17/annie_tank_flux.*.root
+#/mygen/neutrinosdirectory /pnfs/annie/persistent/simulations/genie3/G1810a0211a/standard/tank/gntp.1.ghep.root
+#/mygen/primariesdirectory /pnfs/annie/persistent/simulations/genie3/G1810a0211a/standard/tank/annie_tank_flux.1.root
+#/mygen/neutrinosdirectory /annie/app/users/jminock/genie_shed/gntp.1.ghep.root
+#/mygen/primariesdirectory /annie/app/users/jminock/genie_shed/annie_tank_flux.1.root
+#/mygen/neutrinosdirectory ./gntp.*.ghep.root
+#/mygen/primariesdirectory ./annie_tank_flux.*.root
+/mygen/neutrinosdirectory /pnfs/annie/persistent/simulations/genie3/G1810a0211a/standardv1.0/tank/gntp.0.ghep.root
+/mygen/primariesdirectory /pnfs/annie/persistent/simulations/g4dirt/G1810a0211a/standardv1.0/tank/annie_tank_flux.0.root
 /mygen/primariesoffset 0

--- a/macros/tuning_parameters.mac
+++ b/macros/tuning_parameters.mac
@@ -19,7 +19,7 @@
 /WCSim/tuning/holder 1
 
 #Turning PMT-wise Q.E. on (1) or off (0)
-/WCSim/tuning/PMTwiseQE 1
+/WCSim/tuning/PMTwiseQE 0
 
 # Parameters to set up Top Veto - jl145
 # Set to "1" to turn on top veto.

--- a/sample-root-scripts/sample_readfile.C
+++ b/sample-root-scripts/sample_readfile.C
@@ -2,6 +2,15 @@
 #include <TH1F.h>
 #include <stdio.h>     
 #include <stdlib.h>    
+#include <TFile.h>
+#include <TTree.h>
+#include <TSystem.h>
+#include <TCanvas.h>
+#include <TClonesArray.h>
+
+#include "WCSimRootEvent.hh"
+#include "WCSimRootGeom.hh"
+#include "WCSimRootOptions.hh"
 // Simple example of reading a generated Root file
 void sample_readfile(char *filename=NULL, bool verbose=false)
 {
@@ -56,7 +65,7 @@ void sample_readfile(char *filename=NULL, bool verbose=false)
   }
   if (!file->IsOpen()){
     cout << "Error, could not open input file: " << filename << endl;
-    return -1;
+    return;
   }
   
   // Get the a pointer to the tree from the file
@@ -168,7 +177,9 @@ void sample_readfile(char *filename=NULL, bool verbose=false)
         printf("  Track initial momentum magnitude [MeV/c]: %f\n", wcsimroottrack->GetP());
         printf("  Track mass [MeV/c2]: %f\n", wcsimroottrack->GetM());
         printf("  Track ID: %d\n", wcsimroottrack->GetId());
-      }
+	printf("PrimaryParentID: %d\n", wcsimroottrack->GetPrimaryParentID());
+        printf("  DirectParentID: %d\n", wcsimroottrack->GetDirectParentID());      
+}
 
       
     }  // End of loop over tracks
@@ -278,7 +289,8 @@ void sample_readfile(char *filename=NULL, bool verbose=false)
                 if(thehittimeobject){
                   cout<<"  digit "<<i<<" photon "<<photonid<<": ";
                   cout<<" HitTime index "<<thephotonsid<<", pre-smear time "<<thehittimeobject->GetTruetime()
-                      <<", parent TrackID: "<<thehittimeobject->GetParentID()<<";";
+	          <<", PrimaryParentID: "<<thehittimeobject->GetPrimaryParentID()
+                  <<", DirectParentID: "<<thehittimeobject->GetDirectParentID()<<";";
                 }
                 cout<<endl;
                 photonid++;

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -613,6 +613,7 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
      // std::vector<int>   primaryParentID2;
      double hit_time_smear, hit_time_true;
      int hit_parentid; G4int id0=0;
+     int hit_directparentid;
      //loop over the DigitsCollection
      for(int idigi = 0; idigi < WCDC_hitslappd->entries(); idigi++) {
         int digi_tubeid = (*WCDC_hitslappd)[idigi]->GetTubeID();
@@ -622,11 +623,14 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
         for(G4int id = 0; id < (*WCDC_hitslappd)[idigi]->GetTotalPe(); id++){
           id0++;
           hit_time_true  = (*WCDC_hitslappd)[idigi]->GetPreSmearTime(id);
-          hit_parentid = (*WCDC_hitslappd)[idigi]->GetParentID(id);
+          hit_parentid = (*WCDC_hitslappd)[idigi]->GetPrimaryParentID(id);
+          hit_directparentid = (*WCDC_hitslappd)[idigi]->GetDirectParentID(id);
+
           //G4cout<<"0___LAPPD idigi= "<<idigi<<" id= "<<id<<"/"<<(*WCDC_hitslappd)[idigi]->GetTotalPe()<<G4endl;
           //G4cout<<"id0= "<<id0<<" hit_time_true= "<<hit_time_true<<" hit_parentid= "<<hit_parentid<<G4endl;
           lappdhit_truetime2.push_back(hit_time_true);
           lappdhit_primaryParentID2.push_back(hit_parentid);
+          lappdhit_directParentID2.push_back(hit_directparentid);
           ////---strip number and digitised hits-----
           int stripno = (*WCDC_hitslappd)[idigi]->GetStripNo(id);
           lappdhit_stripnum.push_back(stripno);
@@ -670,11 +674,13 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
         if(digi_tubeid < NPMTS_VERBOSE) {
           G4cout << "Adding " << lappdhit_truetime2.size()
                  << " Cherenkov hits in tube " << digi_tubeid
-                 << " with truetime:smeartime:primaryparentID";
+                 << " with truetime:smeartime:primaryparentID:directparentID"
+                 ;
           for(G4int id = 0; id < lappdhit_truetime2.size(); id++) {
              G4cout << " " << lappdhit_truetime2[id]
                     << ":" << lappdhit_smeartime2[id]
-                    << ":" << lappdhit_primaryParentID2[id];
+                    << ":" << lappdhit_primaryParentID2[id]
+                    << ":" << lappdhit_directParentID2[id];
           }//id
          G4cout << G4endl;
         }
@@ -683,6 +689,7 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
         smeartime2.clear();
         truetime2.clear();
         primaryParentID2.clear();
+        directParentID2.clear();
         */
       } //idigi
     }
@@ -702,6 +709,7 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
     lappdhit_smeartime2.clear();
     lappdhit_truetime2.clear();
     lappdhit_primaryParentID2.clear();
+    lappdhit_directParentID2.clear();
     lappdhit_stripnum.clear();
     lappdhit_neighstripnum.clear();
     lappdhit_neighstrippeak.clear();
@@ -1383,7 +1391,9 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
                                "NuIntx",                  // end process name
                                pdir2,                     // tank exit position (N/A)
                                0,                         // tank exit energy (relativistic)
-                               pdir2);                    // tank exit 3-momentum (N/A)
+                               pdir2,                     // tank exit 3-momentum (N/A)
+                              -1,
+                            -1);                    
     }
     
     // the rest of the tracks come from WCSimTrajectory
@@ -1561,7 +1571,20 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
                                    endProcess,    // end process name
                                    tankexit,      // tank exit position
                                    tankExitE,     // tank exit energy (relativistic)
-                                   tankexitp);    // tank exit 3-momentum
+                                   tankexitp,    // tank exit 3-momentum
+                                   trj->GetPrimaryParentID(),  // primaryParentID
+                                   trj->GetParentID());        // directParentID
+        
+        // DEBUG: Print parent IDs being written to ROOT
+        static int rootDebugCount = 0;
+        if(rootDebugCount < 10) {
+          G4cout << "DEBUG WCSimEventAction: Writing Track #" << rootDebugCount
+                 << " TrackID=" << id
+                 << " PrimaryParentID=" << trj->GetPrimaryParentID()
+                 << " DirectParentID=" << trj->GetParentID()
+                 << " PDG=" << ipnu << G4endl;
+          rootDebugCount++;
+        }
         }
         
         
@@ -1622,16 +1645,20 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
     wcsimrootevent->SetNumTubesHit(WCDC_hits->entries());
     std::vector<float> truetime, smeartime;
     std::vector<int>   primaryParentID;
+    std::vector<int>   directParentID;
     double hit_time_smear, hit_time_true;
     int hit_parentid;
+    int hit_directparentid;
     //loop over the DigitsCollection
     for(int idigi = 0; idigi < WCDC_hits->entries(); idigi++) {
       int digi_tubeid = (*WCDC_hits)[idigi]->GetTubeID();
       for(G4int id = 0; id < (*WCDC_hits)[idigi]->GetTotalPe(); id++){
 	hit_time_true  = (*WCDC_hits)[idigi]->GetPreSmearTime(id);
-	hit_parentid = (*WCDC_hits)[idigi]->GetParentID(id);
+	hit_parentid = (*WCDC_hits)[idigi]->GetPrimaryParentID(id);
+  hit_directparentid = (*WCDC_hits)[idigi]->GetDirectParentID(id);
 	truetime.push_back(hit_time_true);
 	primaryParentID.push_back(hit_parentid);
+  directParentID.push_back(hit_directparentid);
 #ifdef _SAVE_RAW_HITS_VERBOSE
 	hit_time_smear = (*WCDC_hits)[idigi]->GetTime(id);
 	smeartime.push_back(hit_time_smear);
@@ -1652,10 +1679,12 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 #endif
       wcsimrootevent->AddCherenkovHit(digi_tubeid,
 				      truetime,
-				      primaryParentID);
+              primaryParentID,
+              directParentID);
       smeartime.clear();
       truetime.clear();
       primaryParentID.clear();
+      directParentID.clear();
     }//idigi
   }//if(WCDC_hits)
 #endif //_SAVE_RAW_HITS
@@ -1797,6 +1826,7 @@ void WCSimEventAction::CreateNewLAPPDFile(){
   LAPPDtree->Branch("lappdhit_truetime2",&lappdhit_truetime2);
   LAPPDtree->Branch("lappdhit_smeartime2", &lappdhit_smeartime2);
   LAPPDtree->Branch("lappdhit_primaryParentID2",&lappdhit_primaryParentID2);
+  LAPPDtree->Branch("lappdhit_directParentID2",&lappdhit_directParentID2);
   LAPPDtree->Branch("lappdhit_NoOfneighstripsHit", &lappdhit_NoOfneighstripsHit);
   LAPPDtree->Branch("lappdhit_neighstripnum", &lappdhit_neighstripnum);
   LAPPDtree->Branch("lappdhit_neighstrippeak", &lappdhit_neighstrippeak);

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -288,7 +288,9 @@ WCSimRootTrack *WCSimRootTrigger::AddTrack(Int_t ipnu,
 					   std::string eProcess,
 					   Float_t tankexitp[3],
 					   Double_t tankexite,
-					   Float_t tankexitmom[3])
+             Float_t tankexitmom[3],
+             Int_t primaryParentID,
+             Int_t directParentID)
 {
   // Add a new WCSimRootTrack to the list of tracks for this event.
   // To avoid calling the very time consuming operator new for each track,
@@ -320,7 +322,9 @@ WCSimRootTrack *WCSimRootTrigger::AddTrack(Int_t ipnu,
 					   eProcess,
 					   tankexitp,
 					   tankexite,
-					   tankexitmom);
+					   tankexitmom,
+             primaryParentID,
+             directParentID);
 
   return track;
 }
@@ -406,7 +410,10 @@ void WCSimRootTrigger::Print(int verbosity, int maxprimariestoprint, int maxtrac
       int thephotonsid = truephotonindices.at(photoni);
       WCSimRootCherenkovHitTime *thehittimeobject = 
         (WCSimRootCherenkovHitTime*)firsttrig->GetCherenkovHitTimes()->At(thephotonsid);
-      Int_t thephotonsparenttrackid = thehittimeobject->GetParentID();
+        Int_t thephotonsprimaryparenttrackid = thehittimeobject->GetPrimaryParentID();
+        Int_t thephotonsparenttrackid = thehittimeobject->GetDirectParentID(); //Is it related to the DirectParentID or PrimaryParentID? (DJA)
+     
+
      std::cout<<"        digit "<<digiti<<", photon "<<photoni<<" has truetime "<<thehittimeobject->GetTruetime()<<std::endl;
     }
   }
@@ -437,7 +444,9 @@ WCSimRootTrack::WCSimRootTrack(Int_t ipnu,
 				 std::string eProcess,
 				 Float_t tankexitp[3],
 				 Double_t tankexite,
-				 Float_t tankexitmom[3])
+				 Float_t tankexitmom[3],
+         Int_t primaryParentID,
+         Int_t directParentID)
 {
 
   // Create a WCSimRootTrack object and fill it with stuff
@@ -469,6 +478,8 @@ WCSimRootTrack::WCSimRootTrack(Int_t ipnu,
   fStartProcess = sProcess;
   fEndProcess = eProcess;
   fTankExitE = tankexite;
+  fPrimaryParentID = primaryParentID;
+  fDirectParentID = directParentID;
 }
 
 //_____________________________________________________________________________
@@ -480,7 +491,7 @@ void WCSimRootTrack::Clear(Option_t* /*o*/){
 
 //_____________________________________________________________________________
 
-WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID,std::vector<Float_t> truetime,std::vector<Int_t> primParID)
+WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID,std::vector<Float_t> truetime,std::vector<Int_t> primParID, std::vector<Int_t> directParentID)
 {
   // Add a new Cherenkov hit to the list of Cherenkov hits
   TClonesArray &cherenkovhittimes = *fCherenkovHitTimes;
@@ -490,7 +501,7 @@ WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID,std::vecto
     fCherenkovHitCounter++;
 
     WCSimRootCherenkovHitTime *cherenkovhittime = 
-      new(cherenkovhittimes[fNcherenkovhittimes++]) WCSimRootCherenkovHitTime(truetime[i],primParID[i]);
+      new(cherenkovhittimes[fNcherenkovhittimes++]) WCSimRootCherenkovHitTime(truetime[i],primParID[i], directParentID[i]);
   }
 
   Int_t WC_Index[2];
@@ -518,11 +529,12 @@ WCSimRootCherenkovHit::WCSimRootCherenkovHit(Int_t tubeID,
 }
 
 WCSimRootCherenkovHitTime::WCSimRootCherenkovHitTime(Float_t truetime,
-						     Int_t primParID)
+						     Int_t primParID, Int_t directParID)
 {
   // Create a WCSimRootCherenkovHit object and fill it with stuff
     fTruetime        = truetime; 
     fPrimaryParentID = primParID;
+    fDirectParentID = directParID;
 }
 
 //_____________________________________________________________________________

--- a/src/WCSimTrackInformation.cc
+++ b/src/WCSimTrackInformation.cc
@@ -8,6 +8,7 @@ WCSimTrackInformation::WCSimTrackInformation(const G4Track* /*atrack*/)
   saveit = true;
   parentPdg=0;
   primaryParentID=-1;
+  directParentID=-1;
   //numreflections=0;
 }
 

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -146,6 +146,7 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack){
         WCSimTrackInformation* infoSec = new WCSimTrackInformation(anInfo);
         infoSec->WillBeSaved(false);
         infoSec->SetParentPdg(thispdg);
+        infoSec->SetPrimaryParentID(anInfo->GetPrimaryParentID()); // pass down primary parent ID, Do I need to set DirectParentID too? (DJA)
         (*secondaries)[i]->SetUserInformation(infoSec);
       }
   }
@@ -163,7 +164,19 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack){
     currentTrajectory->SetStoppingTime(currentTime);
     currentTrajectory->SetStoppingMomentum(currentMomentum);
     currentTrajectory->SetParentPdg(anInfo->GetParentPdg());
+    currentTrajectory->SetPrimaryParentID(anInfo->GetPrimaryParentID());
     currentTrajectory->SetSaveFlag(anInfo->isSaved());
+    
+    // DEBUG: Print parent IDs for first few tracks
+    static int trackDebugCount = 0;
+    if(trackDebugCount < 10 && anInfo->isSaved()) {
+      G4cout << "DEBUG WCSimTrackingAction: Track #" << trackDebugCount
+             << " TrackID=" << aTrack->GetTrackID()
+             << " PrimaryParentID=" << anInfo->GetPrimaryParentID()
+             << " DirectParentID(ParentID)=" << aTrack->GetParentID()
+             << " PDG=" << aTrack->GetDefinition()->GetPDGEncoding() << G4endl;
+      trackDebugCount++;
+    }
   }
   
   // report every 100000'th track, just to see progress

--- a/src/WCSimTrajectory.cc
+++ b/src/WCSimTrajectory.cc
@@ -18,7 +18,7 @@
 G4Allocator<WCSimTrajectory> myTrajectoryAllocator;
 
 WCSimTrajectory::WCSimTrajectory()
-  :  positionRecord(0), fTrackID(0), fParentID(0), fParentPdg(0),
+  :  positionRecord(0), fTrackID(0), fParentID(0), fPrimaryParentID(-1), fParentPdg(0),
      PDGEncoding( 0 ), PDGCharge(0.0), ParticleName(""),
      initialMomentum( G4ThreeVector() ), finalMomentum( G4ThreeVector() ),
      SaveIt(false),creatorProcess(""), 
@@ -35,6 +35,7 @@ WCSimTrajectory::WCSimTrajectory(const G4Track* aTrack)
   if(fpParticleDefinition==G4OpticalPhoton::OpticalPhotonDefinition()){PDGEncoding=100;}
   fTrackID = aTrack->GetTrackID();
   fParentID = aTrack->GetParentID();
+  fPrimaryParentID = -1;  // Will be set later by WCSimTrackingAction
   initialMomentum = aTrack->GetMomentum();
   finalMomentum = aTrack->GetMomentum();
   globalTimeEnd = aTrack->GetGlobalTime();
@@ -73,6 +74,7 @@ WCSimTrajectory::WCSimTrajectory(WCSimTrajectory & right):G4VTrajectory()
   PDGEncoding = right.PDGEncoding;
   fTrackID = right.fTrackID;
   fParentID = right.fParentID;
+  fPrimaryParentID = right.fPrimaryParentID;
   fParentPdg = right.fParentPdg;
   initialMomentum = right.initialMomentum;
   finalMomentum = right.finalMomentum;

--- a/src/WCSimWCAddDarkNoise.cc
+++ b/src/WCSimWCAddDarkNoise.cc
@@ -334,7 +334,8 @@ void WCSimWCAddDarkNoise::AddDarkNoiseBeforeDigi(WCSimWCDigitsCollection* WCHCPM
 	    //G4cout<<"1 "<<(G4LogicalVolumeStore::GetInstance()->GetVolume("glassFaceWCPMT"))->GetName()<<"\n";
 	    //G4cout<<"2 "<<(*WCHCPMT)[0]->GetLogicalVolume()->GetName()<<"\n";
 	    ahit->SetTrackID(-1);
-	    ahit->SetParentID(PMTindex[noise_pmt], -1);
+	    ahit->SetPrimaryParentID(PMTindex[noise_pmt], -1);
+      ahit->SetDirectParentID(PMTindex[noise_pmt], -1);
 	    // Set the position and rotation of the pmt
 	    Float_t hit_pos[3];
 	    Float_t hit_rot[3];
@@ -373,7 +374,8 @@ void WCSimWCAddDarkNoise::AddDarkNoiseBeforeDigi(WCSimWCDigitsCollection* WCHCPM
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPe(PMTindex[noise_pmt],pe);
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetTime(PMTindex[noise_pmt],current_time);
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPreSmearTime(PMTindex[noise_pmt],current_time); //presmear==postsmear for dark noise
-	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetParentID(PMTindex[noise_pmt],-1);
+	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPrimaryParentID(PMTindex[noise_pmt],-1);
+    (*WCHCPMT)[ list[noise_pmt]-1 ]->SetDirectParentID(PMTindex[noise_pmt],-1);	
 	  PMTindex[noise_pmt]++;
 #ifdef WCSIMWCADDDARKNOISE_VERBOSE
 	  if(noise_pmt < NPMTS_VERBOSE)

--- a/src/WCSimWCLAPPD.cc
+++ b/src/WCSimWCLAPPD.cc
@@ -327,7 +327,8 @@ void WCSimWCLAPPD::MakePeCorrection_lappd(WCSimWCHitsCollection* WCHClappd)
 	  assert(false);
 	}
 	peSmeared = rn1pe(); 
-	int parent_id = (*WCHClappd)[i]->GetParentID(ip);
+	int parent_id = (*WCHClappd)[i]->GetPrimaryParentID(ip);
+  int directparent_id = (*WCHClappd)[i]->GetDirectParentID(ip);
 	//G4cout<<"------- ip= "<<ip<<" time_true= "<<time_true<<" parent_id= "<<parent_id<<G4endl;
 
 	//apply time smearing
@@ -400,7 +401,8 @@ void WCSimWCLAPPD::MakePeCorrection_lappd(WCSimWCHitsCollection* WCHClappd)
 	  Digi->SetPe(ip,peSmeared);
 	  Digi->SetTime(ip,time_LAPPD);
 	  Digi->SetPreSmearTime(ip,time_true);
-	  Digi->SetParentID(ip,parent_id);
+	  Digi->SetPrimaryParentID(ip,parent_id);
+    Digi->SetDirectParentID(ip,directparent_id);
           Digi->SetStripNo(ip,sno);
           Digi->SetNeighStripNo(ip,stripno_peak);
           Digi->SetNeighStripTime(ip,stripno_time);
@@ -415,7 +417,8 @@ void WCSimWCLAPPD::MakePeCorrection_lappd(WCSimWCHitsCollection* WCHClappd)
 	  (*DigitsCollection)[DigiHitMapLAPPD[lappd]-1]->SetPe(ip,peSmeared);
 	  (*DigitsCollection)[DigiHitMapLAPPD[lappd]-1]->SetTime(ip,time_LAPPD);
 	  (*DigitsCollection)[DigiHitMapLAPPD[lappd]-1]->SetPreSmearTime(ip,time_true);
-	  (*DigitsCollection)[DigiHitMapLAPPD[lappd]-1]->SetParentID(ip,parent_id);
+	  (*DigitsCollection)[DigiHitMapLAPPD[lappd]-1]->SetPrimaryParentID(ip,parent_id);
+    (*DigitsCollection)[DigiHitMapLAPPD[lappd]-1]->SetDirectParentID(ip,directparent_id);
  	  (*DigitsCollection)[DigiHitMapLAPPD[lappd]-1]->SetStripNo(ip,sno);
           (*DigitsCollection)[DigiHitMapLAPPD[lappd]-1]->SetNeighStripNo(ip,stripno_peak);
           (*DigitsCollection)[DigiHitMapLAPPD[lappd]-1]->SetNeighStripTime(ip,stripno_time);

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -166,7 +166,8 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      assert(false);
 	    }
 	    peSmeared = rn1pe(PMT);
-	    int parent_id = (*WCHC)[i]->GetParentID(ip);
+	    int parent_id = (*WCHC)[i]->GetPrimaryParentID(ip);
+      int directparent_id = (*WCHC)[i]->GetDirectParentID(ip);
 
 	    //apply time smearing
 	    float Q = (peSmeared > 0.5) ? peSmeared : 0.5;
@@ -181,7 +182,8 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      Digi->SetPe(ip,peSmeared);
 	      Digi->SetTime(ip,time_PMT);
 	      Digi->SetPreSmearTime(ip,time_true);
-	      Digi->SetParentID(ip,parent_id);
+	      Digi->SetPrimaryParentID(ip,parent_id);
+        Digi->SetDirectParentID(ip,directparent_id);
 	      DigiHitMapPMT[tube] = DigitsCollection->insert(Digi);
 	    }	
 	    else {
@@ -192,7 +194,8 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPe(ip,peSmeared);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetTime(ip,time_PMT);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPreSmearTime(ip,time_true);
-	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetParentID(ip,parent_id);
+	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPrimaryParentID(ip,parent_id);
+        (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetDirectParentID(ip,directparent_id);
 	    }
       
 	  } // Loop over hits in each PMT

--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -242,6 +242,17 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
       // =============================
       G4double hitTime           = preStepPoint->GetGlobalTime();
       G4double energyDeposition  = aStep->GetTotalEnergyDeposit();
+      G4int directParentID = aStep->GetTrack()->GetParentID();  //Is it really needed to get direct parent ID from TrackInformation? (DJA)
+      
+      // DEBUG: Print parent IDs for first few hits
+      static int hitDebugCount = 0;
+      if(hitDebugCount < 10) {
+        G4cout << "DEBUG WCSimWCSD: Hit #" << hitDebugCount 
+               << " PrimaryParentID=" << primParentID 
+               << " DirectParentID=" << directParentID 
+               << " TrackID=" << aStep->GetTrack()->GetTrackID() << G4endl;
+        hitDebugCount++;
+      }
       
       // Get information about the sensor
       // ================================
@@ -309,14 +320,16 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
         // Set the hitMap value to the collection hit number
         PMTHitMap[replicaNumber] = hitsCollection->insert( newHit );
         (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPe(hitTime);
-        (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddParentID(primParentID);
+        (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPrimaryParentID(primParentID);
+        (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddDirectParentID(directParentID);
         (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddHitPos(worldPosition);
         if(not isPMT){
           (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddStripPosition(localPosition);
         }
       } else {
         (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPe(hitTime);
-        (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddParentID(primParentID);
+        (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPrimaryParentID(primParentID);
+        (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddDirectParentID(directParentID);
         (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddHitPos(worldPosition);
         if(not isPMT){
           (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddStripPosition(localPosition);


### PR DESCRIPTION
Made improvements on WCSim as per A. Sutton's suggestions, I have uploaded the initial plan of action in [docdb](https://annie-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=6640).

I have updated **WCSim** based on Andrew’s feedback. These changes are necessary for neutron clustering, as using `DirectParent` TrackIDs allows us to identify the immediate parents of MCHits, rather than tracking them back to the primary parents as the current version of WCSim does.

Additionally, I have updated **sample-root-scripts/sample_readfile.C** to read WCSim files standalone for verification purposes, without need of ToolAnalysis.

I am also currently integrating these WCSim changes into the **ToolAnalysis** workflow. This is almost complete; I am performing final-stage testing and ensuring compatibility with the recent changes in **EventBuildingV2**.

P.S.:- Please let me know if you would like me to give a short presentation on these updates during the next software/analysis meeting.